### PR TITLE
Add authorization handling to HttpClient and TusClient

### DIFF
--- a/include/TusClient.h
+++ b/include/TusClient.h
@@ -146,8 +146,8 @@ namespace TUS
         void sanitizeEndpoint();
 
     public:
-        TusClient(string appName, string url, path filePath, int chunkSize,Logging::LogLevel logLevel=Logging::LogLevel::_NONE_);
-        TusClient(string appName, string url, path filePath,Logging::LogLevel logLevel=Logging::LogLevel::_NONE_);
+        TusClient(string appName, string url, path filePath, int chunkSize, Logging::LogLevel logLevel = Logging::LogLevel::_NONE_);
+        TusClient(string appName, string url, path filePath, Logging::LogLevel logLevel = Logging::LogLevel::_NONE_);
         ~TusClient();
         /**
          * @brief Uploads the file to the server using the TUS protocol.
@@ -198,8 +198,18 @@ namespace TUS
 
         path getFilePath() const override;
         string getUrl() const override;
-        void setRequestTimeout(std::chrono::milliseconds ms) override;     
+        void setRequestTimeout(std::chrono::milliseconds ms) override;
         std::chrono::milliseconds getRequestTimeout() const override;
+        /**
+         * @brief set the authrorization token, verify that token is valid,
+         * if not update the token and pass the updated once
+         */
+        void setBearerToken(const std::string& token);
+        /**
+         * @brief This function return if token is set, 
+         * if token is set
+         */
+        bool isTokenSetted();
     };
 } // namespace TUS
 #endif // INCLUDE_TUSCLIENT_H_

--- a/include/http/HttpClient.h
+++ b/include/http/HttpClient.h
@@ -54,9 +54,11 @@ namespace TUS
              */
             IHttpClient* execute()override;
 
-         
+            void setAuthorization(const std::string& token) override;
+            bool isAuthenticated() override;
             
             static string convertHttpMethodToString(HttpMethod method);
+            static int getHttpReturnCode(const std::string& header);
 
         private:
             void setupCURLRequest(CURL *curl, HttpMethod method, Request request);
@@ -65,6 +67,7 @@ namespace TUS
             bool m_abort = false;
             std::mutex m_queueMutex;  // Mutex to protect shared resources
             std::shared_ptr<TUS::Logging::ILogger> m_logger;
+            std::string m_token="";
 
             /**
              * @brief Callback function for the write data of the request

--- a/include/http/IHttpClient.h
+++ b/include/http/IHttpClient.h
@@ -77,6 +77,14 @@ namespace TUS
             virtual IHttpClient* execute() = 0;
           
             virtual ~IHttpClient() {};
+            /**
+             * @brief set the token for the authentication
+             */
+            virtual void setAuthorization(const std::string& token)=0;
+            /**
+             * @brief return if token is set
+             */
+            virtual bool isAuthenticated()=0;
 
 
         };

--- a/mockoon-data.json
+++ b/mockoon-data.json
@@ -435,6 +435,91 @@
       ],
       "responseMode": null,
       "type": "http"
+    },
+    {
+      "uuid": "47e5363b-f2b5-4388-8f88-7369ef7f1750",
+      "documentation": "POST request for /files",
+      "method": "post",
+      "endpoint": "auth/files",
+      "responses": [
+        {
+          "uuid": "385230ce-b1f4-4da3-99b9-b45876df005b",
+          "body": "{\"test\":\"post passed\"}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Authorized",
+          "headers": [
+            {
+              "key": "Access-Control-Allow-Origin",
+              "value": "*"
+            },
+            {
+              "key": "Access-Control-Allow-Methods",
+              "value": "OPTIONS, POST, PATCH, HEAD"
+            },
+            {
+              "key": "Access-Control-Allow-Headers",
+              "value": "Content-Type, Tus-Resumable, Upload-Length, Upload-Offset, Origin, X-Requested-With, Content-Disposition"
+            },
+            {
+              "key": "Access-Control-Expose-Headers",
+              "value": "Location, Upload-Offset"
+            },
+            {
+              "key": "Tus-Resumable",
+              "value": "1.0.0"
+            },
+            {
+              "key": "Location",
+              "value": "http://localhost:3000/files/{fileId}"
+            },
+            {
+              "key": "Content-Length",
+              "value": "0"
+            }
+          ],
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "Authorization",
+              "value": "Bearer WAmjPKLlw6287Ky9L8mVSvI0cwEu5gvd1Y0cj9uPioLlR0E6CJqmExeJOgaO6YV5YECMctqSYQPRR6eC9p3hag5rkBdMjA7Z6Y6zQfDofepIuOwdZ820qDpfljB",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "databucketID": "",
+          "bodyType": "INLINE",
+          "crudKey": "id",
+          "callbacks": [],
+          "filePath": ""
+        },
+        {
+          "uuid": "54f03162-6182-41c2-9782-199079c9371a",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 401,
+          "label": "Unauthorized",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "type": "http"
     }
   ],
   "proxyMode": false,
@@ -507,6 +592,10 @@
     {
       "type": "route",
       "uuid": "0d390305-5755-445e-9935-d6f9ce13d39b"
+    },
+    {
+      "type": "route",
+      "uuid": "47e5363b-f2b5-4388-8f88-7369ef7f1750"
     }
   ],
   "callbacks": []

--- a/src/TusClient.cpp
+++ b/src/TusClient.cpp
@@ -458,13 +458,20 @@ std::chrono::milliseconds TusClient::getRequestTimeout() const
     return m_requestTimeout;
 }
 
+void TUS::TusClient::setBearerToken(const std::string& token)
+{
+    m_httpClient->setAuthorization(token);
+}
+
+bool TUS::TusClient::isTokenSetted()
+{
+   return m_httpClient->isAuthenticated();
+}
+
 void TusClient::setRequestTimeout(std::chrono::milliseconds ms)
 {
     m_requestTimeout = ms;
 }
-
-
-
 
 void TusClient::sanitizeUrl()
 {

--- a/test/http/HttpClientTest.cpp
+++ b/test/http/HttpClientTest.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 #include <functional>
 #include <gtest/gtest.h>
-
+#include <iostream>
 #include "http/HttpClient.h"
 #include "http/Request.h"
 namespace TUS::Test::Http {
@@ -130,6 +130,7 @@ TEST_F(HttpClientParameterizedTest, HttpsRequest)
     {
         std::cout << data << std::endl;
         std::cout << header << std::endl;
+        
         ASSERT_TRUE(data.size() > 0);
     });
     request.setOnErrorCallback( [this](std::string header,
@@ -143,4 +144,44 @@ TEST_F(HttpClientParameterizedTest, HttpsRequest)
 
 }
 
+TEST_F(HttpClientParameterizedTest, AuthorizedRequestSuccess)
+{
+    Request request("http://localhost:3000/auth/files", "", HttpMethod::_POST);
+    request.setOnSuccessCallback( [this](std::string header,
+                                             std::string data)
+    {
+        ASSERT_EQ(HttpClient::getHttpReturnCode(header), 200);
+    });
+    request.setOnErrorCallback( [this](std::string header,
+                                             std::string data)
+    {
+        FAIL();
+    });
+    m_httpClient->setAuthorization("WAmjPKLlw6287Ky9L8mVSvI0cwEu5gvd1Y0cj9uPioLlR0E6CJqmExeJOgaO6YV5YECMctqSYQPRR6eC9p3hag5rkBdMjA7Z6Y6zQfDofepIuOwdZ820qDpfljB");
+    m_httpClient->post(request);
+    m_httpClient->execute();
+
+
+}
+
+TEST_F(HttpClientParameterizedTest, AuthorizedRequestFail)
+{
+    Request request("http://localhost:3000/auth/files", "", HttpMethod::_POST);
+    request.setOnSuccessCallback( [this](std::string header,
+                                             std::string data)
+    {
+        FAIL();
+    });
+    request.setOnErrorCallback( [this](std::string header,
+                                             std::string data)
+    {
+        ASSERT_EQ(HttpClient::getHttpReturnCode(header),401);
+
+    });
+    m_httpClient->setAuthorization("wrongToken");
+    m_httpClient->post(request);
+    m_httpClient->execute();
+
+
+}
 } // namespace TUS::Test::Http


### PR DESCRIPTION
- Implement setAuthorization and isAuthenticated methods in HttpClient.
- Add setBearerToken and isTokenSetted methods in TusClient.
- Update HttpClient to include authorization token in requests.
- Enhance error handling in HttpClient for HTTP response codes.
- Add tests for authorized and unauthorized requests in HttpClientTest.