### PR TITLE
Add vcpkg portfile, update dependencies, and enhance README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ mkdir build
 cd build
 cmake .. --preset {YOUR-SELECTED-PRESET}
 cmake --build .
+cmake --install .
 ```
 After completing these steps, you should have the TusClient library built and ready to use.
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,10 +1,13 @@
-# Config.cmake.in
-
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/libtusclientTargets.cmake")
 
-check_required_components(libtusclient)
-
 include(CMakeFindDependencyMacro)
 
+find_dependency(CURL REQUIRED)
+find_dependency(boost_lexical_cast REQUIRED)
+find_dependency(boost_uuid REQUIRED)
+find_dependency(nlohmann_json REQUIRED)
+find_dependency(glog REQUIRED)
+
+check_required_components(libtusclient)

--- a/portfile.cmake
+++ b/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Cadons/libtusclient
+        REF 1.0.1
+        SHA512 dbe0aeb64eee28aa8fe3f0acedcbfe09d3424ba79ed25168a8919c1ff43b262ecac0410fb6be2a23fec5769bdb6f0b2f44d996545bd2ab1d0f129b234e5549c7
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+        -DBUILD_TEST=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+


### PR DESCRIPTION
- Introduce `portfile.cmake` for vcpkg integration.
- Add required dependencies: CURL, Boost (lexical_cast, uuid), nlohmann_json, and glog.
- Update README.md to include `cmake --install .` in build instructions.
- Refine `Config.cmake.in` for dependency checks and setup.